### PR TITLE
Implement objdiff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 disks/
 expected/
 local.mk
+objdiff.json

--- a/Makefile
+++ b/Makefile
@@ -44,18 +44,26 @@ DEPFLAGS = -MM -MF $(@:.o=.d) -MT $@
 LDFLAGS := -g $(addprefix -T ,$(CPPLDSCRIPT)) -static \
 	   -Wl,--no-check-sections -Wl,-Map=% -Wl,--build-id=none
 
-SRC := \
-	$(wildcard asm/main/*.s) \
-	$(wildcard asm/main/data/*.s) \
-	$(wildcard asm/main/data/psyq/*.s) \
-	$(wildcard asm/main/psyq/*.s) \
-	$(BUILDDIR)/generated/bss.s \
-	$(BUILDDIR)/generated/sbss.s \
+MAIN_C_SRC := \
 	src/main/aabb.c \
 	src/main/butterfly.c \
 	src/main/kar.c \
 	src/main/particle.c \
 	src/main/swap.c
+
+MAIN_C_BASENAMES := $(notdir $(MAIN_C_SRC:.c=))
+MAIN_ASM_FILTERED := $(filter-out $(addprefix asm/main/,$(addsuffix .s,$(MAIN_C_BASENAMES))),$(wildcard asm/main/*.s))
+MAIN_ASM_EXPECTED := $(addprefix asm/main/,$(addsuffix .s,$(MAIN_C_BASENAMES)))
+MAIN_ASM_EXPECTED_OBJ := $(MAIN_ASM_EXPECTED:%=$(BUILDDIR)/%.o)
+
+SRC := \
+	$(MAIN_ASM_FILTERED) \
+	$(wildcard asm/main/data/*.s) \
+	$(wildcard asm/main/data/psyq/*.s) \
+	$(wildcard asm/main/psyq/*.s) \
+	$(BUILDDIR)/generated/bss.s \
+	$(BUILDDIR)/generated/sbss.s \
+	$(MAIN_C_SRC)
 
 OBJ := $(SRC:%=$(BUILDDIR)/%.o)
 DEP := $(OBJ:%.o=%.d)
@@ -259,7 +267,7 @@ all: $(EXE)
 compare:
 	@tools/cmp_bins.sh
 
-expected: all
+expected: all $(MAIN_ASM_EXPECTED_OBJ)
 	@mkdir -p $(EXPECTEDDIR)
 	mv $(BUILDDIR)/asm $(EXPECTEDDIR)/asm
 	mv $(BUILDDIR)/src $(EXPECTEDDIR)/src

--- a/config/main.yaml
+++ b/config/main.yaml
@@ -21,6 +21,7 @@ options:
   ld_gp_expression: main_SDATA_START + 0x8000
 
   generate_asm_macros_files: False
+  make_full_disasm_for_code: True
 
   section_order: [".text", ".rodata", ".data", ".sdata", ".sbss", ".bss"]
 

--- a/tools/objdiff/config-retail.yaml
+++ b/tools/objdiff/config-retail.yaml
@@ -1,0 +1,12 @@
+categories:
+  - id: main
+    name: Main Executable
+    paths:
+      - ""
+
+expected_paths:
+  ALL:  expected/
+
+ignored_files: []
+
+output: ./objdiff.json

--- a/tools/objdiff/objdiff_generate.py
+++ b/tools/objdiff/objdiff_generate.py
@@ -1,0 +1,185 @@
+# Adapted from https://github.com/Vatuu/silent-hill-decomp/tree/master
+
+from pathlib import Path
+from argparse import ArgumentParser
+from dataclasses import dataclass, asdict
+from elftools.elf.elffile import ELFFile
+import logging
+import yaml
+import json
+import sys
+import re
+
+@dataclass
+class UnitMetadata:
+    progress_categories: list[str]
+    source_path: str
+
+@dataclass
+class Unit:
+    name: str
+    base_path: str
+    target_path: str
+    metadata: UnitMetadata
+    symbol_mappings: dict[str, str]
+
+@dataclass
+class ProgressCategory:
+    id: str
+    name: str
+
+@dataclass
+class Config:
+    build_base: bool
+    build_target: bool
+    custom_make: str
+    custom_args: list[str]
+    units: list[Unit]
+    progress_categories: list[ProgressCategory]
+
+
+def _create_config():
+    parser = ArgumentParser()
+    parser.add_argument("config", type = Path)
+    parser.add_argument("version", type = str)
+    parser.add_argument("--ninja", action="store_true")
+    args = parser.parse_args()
+
+    if not args.config.exists() or args.config.is_dir() or args.config.suffix != ".yaml":
+        raise ValueError(f"The given path {args.objects} is not pointing towards a valid config.")
+
+    global is_ninja
+    is_ninja = (args.ninja) or False
+    
+    global game_version
+    game_version = (args.version)
+    
+    with open(args.config) as stream:
+        try:
+            return yaml.safe_load(stream)
+        except yaml.YAMLError as exc:
+            raise exc
+
+def _read_symbols_from_elf(path: Path):
+    addr_to_name = {}
+    with open(path, 'rb') as f:
+        elffile = ELFFile(f)
+
+        for section in elffile.iter_sections():
+            if not hasattr(section, 'iter_symbols'):
+                continue
+            for sym in section.iter_symbols():
+                if sym['st_info']['type'] != 'STT_FUNC':
+                    continue  # skip non-function symbols
+                addr = sym['st_value']
+                name = sym.name
+                if addr != 0 and name:  # skip undefined/empty
+                    addr_to_name[addr] = name
+    return addr_to_name
+
+def _normalize_suffixed_symbols(path: Path):
+    """Scan elf for symbols with numeric suffixes, return a dictionary of non-suffix -> suffix pairs"""
+    symbols = _read_symbols_from_elf(path)
+    suffix_pattern = re.compile(r'\.(\d+)$')
+    normalized = {}
+
+    for name in symbols.values():
+        match = suffix_pattern.search(name)
+        if match:
+            base_name = name[: match.start()]  # strip the .<digits> suffix
+            normalized[base_name] = name
+
+    return normalized
+
+EXCLUDED_NAMES = {"data", "rodata", "sdata", "bss"}
+
+def _collect_objects(path: Path, config) -> list[Path]:
+    ignored = config["ignored_files"]
+    return [
+        path for path in path.rglob("*.o")
+        if not any(name in path.name for name in EXCLUDED_NAMES ) and not any(file in str(path) for file in ignored)
+    ]
+
+def _determine_categories(path: Path, config) -> tuple[UnitMetadata, str]:
+    modified_path = path.relative_to(config["expected_paths"][game_version]).as_posix()
+    if game_version == "ALL":
+        modified_path = re.sub(r"^(USA|EUR|JAP)/", "", str(modified_path))
+
+    categories = []
+    for category in config["categories"]:
+        for prefix in category["paths"]:
+            if str(modified_path).startswith(prefix):
+                categories.append(category["id"])
+    fixed_ext = re.sub( r'\.(s|c).o$', '', modified_path)
+    
+    source_path = f"{fixed_ext}.c" if fixed_ext.startswith("src/") else f"src/{fixed_ext}.c"
+
+    if game_version != "ALL":
+        return (UnitMetadata(categories, source_path), fixed_ext, "")
+    else:
+        match = re.search(r"/(USA|EUR|JAP)/", str(path))
+        version_prefix = match[0] if match else ""
+        return (UnitMetadata(categories, source_path), fixed_ext, version_prefix)
+
+def main():
+    logging.basicConfig(level = logging.INFO)
+    config = _create_config()
+    
+    expected_objects = _collect_objects(Path(config["expected_paths"][game_version]), config)
+    
+    ignore_base_paths = ["."]
+    
+    logging.info(f"Accounting for {len(expected_objects)} objects.")
+    units = []
+    build_method = str
+    for file in expected_objects:
+        processed_path = _determine_categories(file, config)
+        input_path = Path(processed_path[1]).as_posix()
+
+        is_src_unit = input_path.startswith("src/")
+
+        if is_src_unit:
+            # For decompiled C units:
+            # base_path = the compiled expected object (expected/src/main/kar.c.o)
+            # target_path = the original asm object (expected/asm/main/kar.s.o)
+            asm_relative = re.sub(r'^src/', 'asm/', input_path)
+            target_path = str(Path(config["expected_paths"][game_version]) / f"{asm_relative}.s.o")
+            base_path = str(file)
+        else:
+            # For asm units, target is the expected asm object, base is the build output
+            target_path = str(file)
+            if game_version != "ALL":
+                base_path = f"build/{input_path}.s.o"
+            else:
+                base_path = f"build{processed_path[2]}{input_path}.s.o"
+                input_path = f"{processed_path[2][1:]}{input_path}"
+
+        if game_version == "ALL" and not is_src_unit:
+            pass  # input_path already adjusted above
+        elif game_version == "ALL" and is_src_unit:
+            input_path = f"{processed_path[2][1:]}{input_path}"
+
+        symbol_mappings = {}
+
+        if is_ninja:
+            unit = Unit(input_path, base_path, target_path, processed_path[0], symbol_mappings)
+            build_method = "ninja"
+        else:
+            unit = Unit(
+                input_path,
+                base_path if Path(base_path).exists() else None,
+                target_path,
+                processed_path[0],
+                symbol_mappings)
+            build_method = "make"
+        units.append(unit)
+    
+    categories = []
+    for category in config["categories"]:
+        categories.append(ProgressCategory(category["id"], category["name"]))
+    
+    with (Path(config["output"])).open("w") as json_file:
+        json.dump(asdict(Config(False, False, build_method, ["progress", f"GAME_VERSION={game_version}"] if build_method != "ninja" and game_version != "ALL" else None, units, categories)), json_file, indent=2)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR aims to implement objdiff on the project. So far, a dynamically-loaded JSON is generated from entering the following commands:
```
make clean
tools/splat.sh
make expected
python3 tools/objdiff/objdiff_generate.py tools/objdiff/config-retail.yaml ALL
```

After the above, objdiff GUI should be able to open up objdiff.json on the project folder like so:

<img width="1419" height="455" alt="imagen" src="https://github.com/user-attachments/assets/6452f8f9-d7e5-4c94-adab-1c6fbd122781" />

The objdiff_generate.py script is borrowed from silent-hill-decomp, like pretty much every other PSX decomp project. Now, here is what else needs to be done:
- Calling splat.sh and objdiff_generate.py manually is bad, there should be a `make setup` and `make report` command for those purposes.
- `make compare` should be run automatically with `make all`, in my opinion.
- objdiff_generate.py here has got quite a few modifications from the [silent-hill-decomp original](https://www.diffchecker.com/HdXZbNab/), which theoretically should work almost as is (only should need changing JAP[0-2] for just JAP) .
- The Makefile is only preparing the required stuff for just the PS-EXE, overlays need to have support too.
- Currently the GUI shows objects split in asm and src directories, it should be just src.
- `make clean` should get rid of both the /build and the /expected dirs.
- An objdiff CLI binary needs to be inserted in the objdiff folder.
- There should be exclusion of PsyQ headers in config-retail.yml.

I'll be working on all this tomorrow. Good news is, this already supports different game regions and needs fairly little to have a progress charter on decomp.dev. Also, this depends on the changes of the [previous PR](https://github.com/jype0/dw_decomp/pull/3). 