### PR TITLE
Report CMD + fix remaining issues with objdiff 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,9 +260,13 @@ compare:
 	@tools/cmp_bins.sh
 
 expected: $(OBJ)
+	rm -rf $(EXPECTEDDIR)
 	@mkdir -p $(EXPECTEDDIR)
 	mv $(BUILDDIR)/asm $(EXPECTEDDIR)/asm
 	mv $(BUILDDIR)/src $(EXPECTEDDIR)/src
+
+report: expected
+	python3 tools/objdiff/objdiff_generate.py tools/objdiff/config-retail.yaml ALL
 
 $(BUILDDIR)/%.ld: %.ld
 	@mkdir -p $(dir $@)

--- a/Makefile
+++ b/Makefile
@@ -262,11 +262,11 @@ compare:
 expected: $(OBJ)
 	rm -rf $(EXPECTEDDIR)
 	@mkdir -p $(EXPECTEDDIR)
-	mv $(BUILDDIR)/asm $(EXPECTEDDIR)/asm
-	mv $(BUILDDIR)/src $(EXPECTEDDIR)/src
+	cp -r $(BUILDDIR)/asm $(EXPECTEDDIR)/asm
+	cp -r $(BUILDDIR)/src $(EXPECTEDDIR)/src
 
 report: expected
-	python3 tools/objdiff/objdiff_generate.py tools/objdiff/config-retail.yaml ALL
+	python3 tools/objdiff/objdiff_generate.py tools/objdiff/config.yaml
 
 $(BUILDDIR)/%.ld: %.ld
 	@mkdir -p $(dir $@)

--- a/Makefile
+++ b/Makefile
@@ -265,7 +265,7 @@ expected: $(OBJ)
 	cp -r $(BUILDDIR)/asm $(EXPECTEDDIR)/asm
 	cp -r $(BUILDDIR)/src $(EXPECTEDDIR)/src
 
-report: expected
+objdiff: expected
 	python3 tools/objdiff/objdiff_generate.py tools/objdiff/config.yaml
 
 $(BUILDDIR)/%.ld: %.ld

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ make -j$(nproc)
 # Compare original vs new binaries
 make compare
 
-# Generate objdiff report 
-make report
+# Generate objdiff config
+make objdiff
 ```
 
 ## Links

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ make -j$(nproc)
 
 # Compare original vs new binaries
 make compare
+
+# Generate objdiff report 
+make report
 ```
 
 ## Links

--- a/tools/objdiff/config-retail.yaml
+++ b/tools/objdiff/config-retail.yaml
@@ -7,6 +7,7 @@ categories:
 expected_paths:
   ALL:  expected/
 
-ignored_files: []
+ignored_files: 
+  - psyq
 
 output: ./objdiff.json

--- a/tools/objdiff/config-retail.yaml
+++ b/tools/objdiff/config-retail.yaml
@@ -2,12 +2,12 @@ categories:
   - id: main
     name: Main Executable
     paths:
-      - ""
+      - main
 
 expected_paths:
   ALL:  expected/
 
 ignored_files: 
-  - psyq
+  - main/psyq
 
 output: ./objdiff.json

--- a/tools/objdiff/config.yaml
+++ b/tools/objdiff/config.yaml
@@ -5,7 +5,7 @@ categories:
       - main
 
 expected_paths:
-  ALL:  expected/
+  asm: expected/asm
 
 ignored_files: 
   - main/psyq

--- a/tools/objdiff/objdiff_generate.py
+++ b/tools/objdiff/objdiff_generate.py
@@ -13,7 +13,6 @@ import re
 @dataclass
 class UnitMetadata:
     progress_categories: list[str]
-    source_path: str
 
 @dataclass
 class Unit:
@@ -41,19 +40,11 @@ class Config:
 def _create_config():
     parser = ArgumentParser()
     parser.add_argument("config", type = Path)
-    parser.add_argument("version", type = str)
-    parser.add_argument("--ninja", action="store_true")
     args = parser.parse_args()
 
     if not args.config.exists() or args.config.is_dir() or args.config.suffix != ".yaml":
         raise ValueError(f"The given path {args.objects} is not pointing towards a valid config.")
 
-    global is_ninja
-    is_ninja = (args.ninja) or False
-    
-    global game_version
-    game_version = (args.version)
-    
     with open(args.config) as stream:
         try:
             return yaml.safe_load(stream)
@@ -101,77 +92,41 @@ def _collect_objects(path: Path, config) -> list[Path]:
     ]
 
 def _determine_categories(path: Path, config) -> tuple[UnitMetadata, str]:
-    modified_path = path.relative_to(config["expected_paths"][game_version]).as_posix()
-    if game_version == "ALL":
-        modified_path = re.sub(r"^(USA|EUR|JAP)/", "", str(modified_path))
+    if path.name.endswith(".s.o"):
+        modified_path = path.relative_to(config["expected_paths"]["asm"])
+    else:
+        modified_path = path.relative_to(config["expected_paths"]["src"])
 
     categories = []
     for category in config["categories"]:
         for prefix in category["paths"]:
-            if str(modified_path).startswith(prefix):
+            if re.sub(r"\\", r"/", str(modified_path)).startswith(prefix):
                 categories.append(category["id"])
-    fixed_ext = re.sub( r'\.(s|c).o$', '', modified_path)
-    
-    source_path = f"{fixed_ext}.c" if fixed_ext.startswith("src/") else f"src/{fixed_ext}.c"
-
-    if game_version != "ALL":
-        return (UnitMetadata(categories, source_path), fixed_ext, "")
-    else:
-        match = re.search(r"/(USA|EUR|JAP)/", str(path))
-        version_prefix = match[0] if match else ""
-        return (UnitMetadata(categories, source_path), fixed_ext, version_prefix)
+    return (UnitMetadata(categories), str(modified_path))
 
 def main():
     logging.basicConfig(level = logging.INFO)
     config = _create_config()
     
-    expected_objects = _collect_objects(Path(config["expected_paths"][game_version]), config)
-    
-    ignore_base_paths = ["."]
+    expected_objects = _collect_objects(Path(config["expected_paths"]["asm"]), config)
     
     logging.info(f"Accounting for {len(expected_objects)} objects.")
     units = []
-    build_method = str
     for file in expected_objects:
         processed_path = _determine_categories(file, config)
-        input_path = Path(processed_path[1]).as_posix()
-
-        is_src_unit = input_path.startswith("src/")
-
-        if is_src_unit:
-            # For decompiled C units:
-            # base_path = the compiled expected object (expected/src/main/kar.c.o)
-            # target_path = the original asm object (expected/asm/main/kar.s.o)
-            asm_relative = re.sub(r'^src/', 'asm/', input_path)
-            target_path = str(Path(config["expected_paths"][game_version]) / f"{asm_relative}.s.o")
-            base_path = str(file)
-        else:
-            # For asm units, target is the expected asm object, base is the build output
-            target_path = str(file)
-            if game_version != "ALL":
-                base_path = f"build/{input_path}.s.o"
-            else:
-                base_path = f"build{processed_path[2]}{input_path}.s.o"
-                input_path = f"{processed_path[2][1:]}{input_path}"
-
-        if game_version == "ALL" and not is_src_unit:
-            pass  # input_path already adjusted above
-        elif game_version == "ALL" and is_src_unit:
-            input_path = f"{processed_path[2][1:]}{input_path}"
-
+        base_path = "build/src/" + re.sub(r"\\", r"/", processed_path[1]).removesuffix(".s.o").removesuffix(".c.o") + ".c.o"
+        
+        # Create mappings for clone/disambiguation symbol suffixes in base object
+        # (disabled as objdiff report doesn't appear to support symbol mappings right now)
+        #symbol_mappings = _normalize_suffixed_symbols(base_path) if Path(base_path).exists() else {}
         symbol_mappings = {}
 
-        if is_ninja:
-            unit = Unit(input_path, base_path, target_path, processed_path[0], symbol_mappings)
-            build_method = "ninja"
-        else:
-            unit = Unit(
-                input_path,
-                base_path if Path(base_path).exists() else None,
-                target_path,
-                processed_path[0],
-                symbol_mappings)
-            build_method = "make"
+        unit = Unit(
+            re.sub(r"\\", r"/", processed_path[1]).removesuffix(".s.o").removesuffix(".c.o"),
+            base_path if Path(base_path).exists() else None,
+            re.sub(r"\\", r"/", str(file)),
+            processed_path[0],
+            symbol_mappings)
         units.append(unit)
     
     categories = []
@@ -179,7 +134,7 @@ def main():
         categories.append(ProgressCategory(category["id"], category["name"]))
     
     with (Path(config["output"])).open("w") as json_file:
-        json.dump(asdict(Config(False, False, build_method, ["progress", f"GAME_VERSION={game_version}"] if build_method != "ninja" and game_version != "ALL" else None, units, categories)), json_file, indent=2)
+        json.dump(asdict(Config(False, False, "make", ["progress"], units, categories)), json_file, indent=2)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR adds the `make report` command to the Makefile, excludes PsyQ headers from progress calculation and fixes a glaring issue where the build folder is moved to the expected folder during execution of `make expected`, instead of copying it.