### PR TITLE
17 new matched functions (main exe)

### DIFF
--- a/config/main.ld
+++ b/config/main.ld
@@ -292,6 +292,8 @@ SECTIONS
         . = ALIGN(., 4);
         build/asm/main/data/main_menu.rodata.s.o(.rodata.*)
         . = ALIGN(., 4);
+        build/src/main/main_menu.c.o(.rodata.* .rodata)
+        . = ALIGN(., 4);
         KEEP(build/asm/main/psyq/libapi.s.o(.rodata.*))
         . = ALIGN(., 4);
         main_RODATA_END = .;

--- a/include/dw/item.h
+++ b/include/dw/item.h
@@ -29,6 +29,6 @@ typedef struct {
 extern Item ITEM_PARA[];
 
 int32_t giveItem(uint32_t type, uint8_t amount);
-void removeItem(uint32_t type, uint8_t amount);
+void removeItem(int32_t type, uint32_t amount);
 
 #endif

--- a/include/dw/model.h
+++ b/include/dw/model.h
@@ -27,6 +27,6 @@ typedef struct {
 } ModelComponent;
 
 void initializeModelComponents(void);
-ModelComponent *getEntityModelComponent(int32_t instance, int32_t type);
+ModelComponent *getEntityModelComponent(int32_t instance, char type);
 
 #endif

--- a/include/dw/script.h
+++ b/include/dw/script.h
@@ -126,7 +126,7 @@ void setTamerState(int8_t state);
 void tickScriptDialogueBox(void);
 void renderScriptDialogueBox(void);
 void returnFromScriptFile(void);
-int32_t getEntityScreenPos(Entity *entity, int32_t flag, int16_t *outPos);
+void getEntityScreenPos(Entity *entity, int32_t flag, int16_t *outPos);
 void readFileSection(char *filename, void *dest, uint32_t offset,
 		     uint32_t size);
 void dailyPStatTrigger(void);

--- a/src/main/efe.c
+++ b/src/main/efe.c
@@ -5,6 +5,12 @@
 #include <dw/types.h>
 #include <libcd.h>
 
+typedef struct {
+	int16_t state;
+	int16_t unk2;
+	int16_t unk4;
+} CloudFXEntry;
+
 extern int16_t MAIN_D_80138AA4[];
 extern int16_t MAIN_D_801389B4[];
 extern char *EFE_FLASH_DATA;
@@ -12,7 +18,7 @@ extern uint32_t MAIN_D_8012343C[];
 extern char MAIN_D_8012342C[];
 extern char MAIN_D_80134220[];
 extern int16_t EFE_LOADED_MOVE_DATA[];
-extern char EFE_SCRIPT_MEM1_DATA;
+extern char EFE_SCRIPT_MEM1_DATA[];
 extern char *EFE_DATA_STACK;
 extern u_long SOME_IMAGE_DATA[];
 void setShortWithStride();
@@ -80,7 +86,7 @@ void renderEntityParticleFX(int32_t id);
 void removeEntityParticleFX();
 void initializeCloudFXData();
 void removeAllCloudFX();
-void createCloudFX(int32_t *pos);
+void createCloudFX(int16_t *pos);
 void tickCloudFX();
 void renderCloudFX(int32_t id);
 void rotateVector();
@@ -196,9 +202,36 @@ void initializeCloudFXData(void)
 	setShortWithStride(MAIN_D_80138AA4, -1, 0x3C, 6);
 }
 
-INCLUDE_ASM("asm/main/nonmatchings/efe", removeAllCloudFX);
+void removeAllCloudFX(void)
+{
+	int32_t i;
 
-INCLUDE_ASM("asm/main/nonmatchings/efe", createCloudFX);
+	for (i = 0; i < 0x3C; i++) {
+		if (((CloudFXEntry *)MAIN_D_80138AA4)[i].state != -1) {
+			((CloudFXEntry *)MAIN_D_80138AA4)[i].state = -1;
+			removeObject(0x601, i);
+		}
+	}
+}
+
+void createCloudFX(int16_t *pos)
+{
+	CloudFXEntry *e;
+	int32_t i;
+
+	for (i = 0; i < 0x3C; i++) {
+		if (((CloudFXEntry *)MAIN_D_80138AA4)[i].state < 0) {
+			break;
+		}
+	}
+	if (i != 0x3C) {
+		e = &((CloudFXEntry *)MAIN_D_80138AA4)[i];
+		e->state = 0;
+		e->unk2 = pos[0];
+		e->unk4 = pos[2];
+		addObject(0x601, i, tickCloudFX, renderCloudFX);
+	}
+}
 
 void tickCloudFX(int32_t id)
 {
@@ -269,7 +302,12 @@ INCLUDE_ASM("asm/main/nonmatchings/efe", modifySomeImage);
 
 INCLUDE_ASM("asm/main/nonmatchings/efe", findEFEDATFile);
 
-INCLUDE_ASM("asm/main/nonmatchings/efe", initializeEFE);
+void initializeEFE(void)
+{
+	setShortWithStride(EFE_LOADED_MOVE_DATA, -1, 0x11, 2);
+	EFE_DATA_STACK = EFE_SCRIPT_MEM1_DATA;
+	findEFEDATFile();
+}
 
 void getEFEDATEntry(int32_t id)
 {

--- a/src/main/item.c
+++ b/src/main/item.c
@@ -416,7 +416,37 @@ int32_t getItemCount(uint8_t type)
 
 INCLUDE_ASM("asm/main/nonmatchings/item", giveItem);
 
-INCLUDE_ASM("asm/main/nonmatchings/item", removeItem);
+void removeItem(int32_t type, uint32_t amount)
+{
+  int32_t new_var;
+  int32_t i;
+  uint8_t *new_var2;
+  uint8_t *amt;
+  if (type == 0xFF)
+  {
+    return;
+  }
+  for (i = 0; i < INVENTORY_SIZE[0]; i++)
+  {
+    if (INVENTORY_ITEM_TYPES.array[i] == type)
+    {
+      amt = (&INVENTORY_ITEM_TYPES.array[i]) + 0x1E;
+      new_var2 = amt;
+      new_var = amount < (*new_var2);
+      if (new_var)
+      {
+        *amt = (*new_var2) - amount;
+      }
+      else
+      {
+        *new_var2 = 0;
+        INVENTORY_ITEM_TYPES.array[i] = 0xFF;
+        INVENTORY_ITEM_NAMES.array[i] = 0xFF;
+      }
+    }
+  }
+
+}
 
 INCLUDE_ASM("asm/main/nonmatchings/item", pickupItem);
 
@@ -561,4 +591,28 @@ void setTrainingBoost(int32_t flag, int32_t value, int32_t duration)
 	PARTNER_PARA.trainBoostTimer = duration * 1200;
 }
 
-INCLUDE_ASM("asm/main/nonmatchings/item", handleItemSickness);
+void handleItemSickness(int16_t chance)
+{
+  int32_t new_var;
+  int16_t r;
+  char buf[0x18];
+  r = (int16_t) random(0x64);
+  new_var = PARTNER_PARA.condition & 0x40;
+  if ((r < chance) && (!new_var))
+  {
+    PARTNER_PARA.condition |= 0x40;
+    PARTNER_PARA.timesBeingSick++;
+    PARTNER_PARA.sicknessTimer = 1;
+    if (PARTNER_PARA.condition & 0x20)
+    {
+      PARTNER_PARA.condition &= ~0x20;
+      PARTNER_PARA.injuryTimer = 0;
+    }
+    setTamerState(0x14);
+    clearTextArea();
+    setTextColor(0xA);
+    sprintf(buf, &MAIN_D_80134368, PARTNER_ENTITY.name);
+    strcat(buf, MAIN_D_80125F64);
+    drawString(buf, 0, 0x78);
+  }
+}

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -13,7 +13,14 @@
 #include <dw/types.h>
 #include <dw/world_object.h>
 
+#include <dw/params.h>
+
 #include "common.h"
+
+int32_t isTriggerSet(uint16_t trigger);
+void unsetTrigger(uint16_t trigger);
+
+
 
 typedef struct {
 	uint32_t unk1;
@@ -441,7 +448,35 @@ INCLUDE_ASM("asm/main/nonmatchings/main", newGameScene);
 
 INCLUDE_ASM("asm/main/nonmatchings/main", MAIN_func_800EF38C);
 
-INCLUDE_ASM("asm/main/nonmatchings/main", recalculatePPandArena);
+void recalculatePPandArena(void)
+{
+	uint8_t pp;
+	int32_t i;
+
+	pp = 0;
+	for (i = 3; i < 0x3B; i++) {
+		if ((DIGIMON_DATA[i].level >= 3) && (isTriggerSet((uint16_t)(0xC8 + i)) != 0)) {
+			if ((i == 0xB) || (i == 0x27) || (i == 0x35)) {
+				pp++;
+			} else {
+				pp += (uint8_t)(DIGIMON_DATA[i].level - 2);
+			}
+		}
+	}
+	writePStat(1, pp);
+	pp = readPStat(3);
+	if (pp >= 0x17) {
+		if (isTriggerSet(0x25) != 0) {
+			unsetTrigger(0x25);
+		}
+		if (isTriggerSet(0x26) != 0) {
+			unsetTrigger(0x26);
+		}
+		if (isTriggerSet(0x27) != 0) {
+			unsetTrigger(0x27);
+		}
+	}
+}
 
 INCLUDE_ASM("asm/main/nonmatchings/main", gameLoop);
 
@@ -727,7 +762,22 @@ void tickNPCBattle(int32_t instanceId)
 	}
 }
 
-INCLUDE_ASM("asm/main/nonmatchings/main", tickNewGameJijimon);
+void tickNewGameJijimon(int32_t instanceId)
+{
+	int16_t *p;
+
+	p = &MAIN_D_80134F10;
+	if (*p < 0x7530) {
+		*p += 1;
+	}
+	if (*p == 0x23) {
+		setEntityRotation(2, 0, 0x71, 0);
+		setupEntityMatrix(2);
+		startAnimation(ENTITY_TABLE[2], 0);
+		writePStat(0xF3, 0);
+	}
+	tickAnimation(ENTITY_TABLE[2]);
+}
 
 void loadNewgameScene(void)
 {

--- a/src/main/main_menu.c
+++ b/src/main/main_menu.c
@@ -182,6 +182,8 @@ typedef struct {
 	int16_t h;
 } MenuHighlight;
 void MAIN_func_801136C8(MenuHighlight *b);
+extern int8_t MAIN_D_80131818[];
+extern MenuHighlight MAIN_D_801316B8[];
 int32_t createByteSum(uint8_t *data, int32_t len);
 void openSaveMachine(void);
 int32_t MAIN_func_801138B0(void);
@@ -912,7 +914,74 @@ int32_t MAIN_func_8011341C(uint8_t *p)
 	return count;
 }
 
-INCLUDE_ASM("asm/main/nonmatchings/main_menu", renderMainMenu);
+void renderMainMenu(void)
+{
+	int8_t menu;
+
+	if (CURRENT_MENU >= 0) {
+		menu = MAIN_D_80131818[CURRENT_MENU];
+		if (menu != -1) {
+			MAIN_func_801136C8(&MAIN_D_801316B8[menu]);
+		}
+		switch (menu) {
+		case 0:
+			MAIN_func_8010D034();
+			break;
+		case 1:
+			MAIN_func_8010D3E0();
+			break;
+		case 2:
+		case 4:
+			MAIN_func_8010D554();
+			break;
+		case 5:
+			MAIN_func_8010D694();
+			break;
+		case 6:
+			MAIN_func_8010D70C();
+			break;
+		case 7:
+			MAIN_func_8010DA44();
+			break;
+		case 8:
+			renderContinueSaveSelection();
+			break;
+		case 9:
+			MAIN_func_8010DEBC();
+			break;
+		case 10:
+			MAIN_func_8010DFAC();
+			break;
+		case 11:
+			MAIN_func_8010E0C8();
+			break;
+		case 12:
+			MAIN_func_8010E16C();
+			break;
+		case 13:
+			MAIN_func_8010E350();
+			break;
+		case 14:
+			MAIN_func_8010E4B8();
+			break;
+		case 15:
+			MAIN_func_8010E638();
+			break;
+		case 16:
+			MAIN_func_8010E73C();
+			break;
+		case 17:
+			MAIN_func_8010E8C0();
+			break;
+		case 18:
+			MAIN_func_8010E938();
+			break;
+		case 19:
+			MAIN_func_8010EA1C();
+			break;
+		}
+	}
+}
 
 void registerBattleData(void)
 {

--- a/src/main/main_menu.c
+++ b/src/main/main_menu.c
@@ -883,7 +883,13 @@ int32_t createByteSum(uint8_t *data, int32_t len)
 	return sum;
 }
 
-INCLUDE_ASM("asm/main/nonmatchings/main_menu", createSavegameChecksum);
+int32_t createSavegameChecksum(int32_t slot)
+{
+	uint32_t first;
+
+	first = createByteSum(&MAIN_D_8013192C[slot * 0xF00] + 0x200, 0x4E4);
+	return first + (uint32_t)createByteSum(&MAIN_D_8013192C[slot * 0xF00] + 0x700, 0xA00);
+}
 
 INCLUDE_ASM("asm/main/nonmatchings/main_menu", loadSavegame);
 

--- a/src/main/model.c
+++ b/src/main/model.c
@@ -290,9 +290,77 @@ void unloadModel(int32_t digiType, int32_t modelType)
 	}
 }
 
-INCLUDE_ASM("asm/main/nonmatchings/model", getEntityModelComponent);
+ModelComponent *getEntityModelComponent(int32_t instance, char type)
+{
+	ModelComponent *p;
+	int32_t i;
 
-INCLUDE_ASM("asm/main/nonmatchings/model", getEntityType);
+	i = type;
+	if (i == 2) {
+		return &TAMER_MODEL;
+	}
+	if (i == 3) {
+		return &PARTNER_MODEL;
+	}
+	if (i == 0) {
+		i = instance;
+		if ((i < 0) || (instance >= 0xB4)) {
+			return 0;
+		}
+		p = NPC_MODEL;
+		for (i = 0; i < 5; p++, i++) {
+			if (p->digiType == instance) {
+				break;
+			}
+		}
+		if (i == 5) {
+			return 0;
+		}
+		if (p->useCount != 0) {
+			goto done;
+		}
+		return 0;
+	}
+	if (i == 1) {
+		i = instance;
+		if ((instance < 0) || (i >= 0x96)) {
+			return 0;
+		}
+		p = &UNKNOWN_MODEL[i];
+		if (p->useCount == 0) {
+			return 0;
+		}
+	}
+done:
+	return p;
+}
+
+int32_t getEntityType(Entity* entity)
+{
+	int32_t i;
+	int32_t v;
+
+	for (i = 0; i < 10; i++) {
+		if (ENTITY_TABLE[i] == entity) {
+			break;
+		}
+	}
+	switch (i) {
+	case 0:
+		v = 2;
+		break;
+	case 1:
+		v = 3;
+		break;
+	case 10:
+		v = -1;
+		break;
+	default:
+		v = 0;
+		break;
+	}
+	return v;
+}
 
 static inline int32_t applyTPageOffset(int32_t tpageOffset,
 				       int32_t pixelOffset)

--- a/src/main/overworld.c
+++ b/src/main/overworld.c
@@ -255,7 +255,7 @@ void renderDateDigits(void);
 void renderTriangleCursor(void);
 void isUIBoxAvailable(void);
 void setSleepDisabled(int32_t arg);
-void removeItem(uint32_t type, uint8_t amount);
+void removeItem(int32_t type, uint32_t amount);
 void startFeedingItem(int32_t arg);
 void removeOneSelectedItem(void);
 void renderFeedingItem(int32_t arg);

--- a/src/main/partner_impl.c
+++ b/src/main/partner_impl.c
@@ -66,7 +66,7 @@ extern int32_t ACTIVE_FRAMEBUFFER;
 extern GsOT GS_ORDERING_TABLE[2];
 extern SVECTOR POOP_ROTATION;
 
-extern int8_t PARTNER_AREA_RESPONSE;
+extern int8_t PARTNER_AREA_RESPONSE[];
 extern uint16_t CURRENT_FRAME;
 extern uint16_t LAST_HANDLED_FRAME;
 extern int32_t MAIN_D_80134C6C;
@@ -322,7 +322,39 @@ INCLUDE_ASM("asm/main/nonmatchings/partner_impl", createPoopPile);
 
 INCLUDE_ASM("asm/main/nonmatchings/partner_impl", sleepRegen);
 
-INCLUDE_ASM("asm/main/nonmatchings/partner_impl", tickTirednessMechanics);
+void tickTirednessMechanics(void)
+{
+	if (((PARTNER_PARA.areaEffectTimer % 1200) == 0) && (PARTNER_PARA.areaEffectTimer > 0)) {
+		if (PARTNER_AREA_RESPONSE[0] == 1) {
+			PARTNER_PARA.happiness = PARTNER_PARA.happiness + 1;
+			PARTNER_PARA.tiredness = PARTNER_PARA.tiredness - 2;
+		}
+		if (PARTNER_AREA_RESPONSE[0] == 2) {
+			PARTNER_PARA.happiness = PARTNER_PARA.happiness - 1;
+			PARTNER_PARA.tiredness = PARTNER_PARA.tiredness + 1;
+		}
+	}
+	if (PARTNER_PARA.subTiredness >= 0x3C) {
+		PARTNER_PARA.tiredness = PARTNER_PARA.tiredness + 1;
+		if (PARTNER_PARA.tiredness >= 0x64) {
+			PARTNER_PARA.tiredness = 0x64;
+		}
+		PARTNER_PARA.subTiredness = 0;
+	}
+	if (PARTNER_PARA.tiredness >= 0x32) {
+		PARTNER_PARA.tirednessHungerTimer = PARTNER_PARA.tirednessHungerTimer + 1;
+	} else {
+		PARTNER_PARA.tirednessHungerTimer = 0;
+	}
+	if (PARTNER_PARA.tiredness >= 0x50) {
+		PARTNER_PARA.condition |= 2;
+		if (((CURRENT_FRAME % 100) == 0) && (CURRENT_FRAME != LAST_HANDLED_FRAME)) {
+			PARTNER_PARA.happiness = PARTNER_PARA.happiness - 2;
+		}
+	} else {
+		PARTNER_PARA.condition &= ~2;
+	}
+}
 
 INCLUDE_ASM("asm/main/nonmatchings/partner_impl", partnerWillRefuseItem);
 

--- a/src/main/tamer.c
+++ b/src/main/tamer.c
@@ -2,6 +2,7 @@
 #include <libgpu.h>
 #include <libgs.h>
 #include <libgte.h>
+#include <mwinline_n.h>
 
 #include <dw/butterfly.h>
 #include <dw/endi.h>
@@ -486,7 +487,78 @@ INCLUDE_ASM("asm/main/nonmatchings/tamer", checkItemPickup);
 
 INCLUDE_ASM("asm/main/nonmatchings/tamer", checkMapInteraction);
 
-INCLUDE_ASM("asm/main/nonmatchings/tamer", checkMedalConditions);
+void checkMedalConditions(void)
+{
+	int32_t i;
+
+	if (hasMedal(5) == 0) {
+		i = 0;
+		while (i < 0x39) {
+			if (hasMove(i) == 0) {
+				break;
+			}
+			i++;
+		}
+		if (i == 0x39) {
+			unlockMedal(5);
+			HAS_MEDAL_AWARD_PENDING = 1;
+		}
+	}
+	if (hasMedal(7) == 0) {
+		BaseStats *bs = &PARTNER_ENTITY.digimonEntity.stats.base;
+		if ((bs->hp == 0x270F) &&
+		    (bs->mp == 0x270F) &&
+		    (bs->off == 0x3E7) &&
+		    (bs->def == 0x3E7) &&
+		    (bs->brain == 0x3E7) &&
+		    (bs->speed == 0x3E7)) {
+			unlockMedal(7);
+			HAS_MEDAL_AWARD_PENDING = 1;
+		}
+	}
+	if ((hasMedal(0xD) == 0) && (MONEY == 0xF423F)) {
+		unlockMedal(0xD);
+		HAS_MEDAL_AWARD_PENDING = 1;
+	}
+	if ((hasMedal(0xE) == 0) && (YEAR == 0xA)) {
+		unlockMedal(0xE);
+		HAS_MEDAL_AWARD_PENDING = 1;
+	}
+	if (hasMedal(6) == 0) {
+		i = 1;
+		while (i < 0x3E) {
+			if (hasDigimonRaised((uint16_t)i) == 0) {
+				break;
+			}
+			i++;
+		}
+		if (i == 0x3E) {
+			unlockMedal(6);
+			HAS_MEDAL_AWARD_PENDING = 1;
+			TAMER_ENTITY.tamerLevel = TAMER_ENTITY.tamerLevel + 1;
+			if (TAMER_ENTITY.tamerLevel >= 0xB) {
+				TAMER_ENTITY.tamerLevel = 0xA;
+			}
+		}
+	}
+	if ((hasMedal(9) == 0) && (PARTNER_PARA.fishCaught >= 0x64)) {
+		unlockMedal(9);
+		HAS_MEDAL_AWARD_PENDING = 1;
+	}
+	if (hasMedal(0xC) == 0) {
+		i = 0;
+		while (i < 0x42) {
+			if (getCardAmount((uint8_t)i) == 0) {
+				break;
+			}
+			i++;
+		}
+		if (i == 0x42) {
+			unlockMedal(0xC);
+			HAS_MEDAL_AWARD_PENDING = 1;
+		}
+	}
+}
 
 void checkPendingAwards(void)
 {
@@ -674,7 +746,28 @@ INCLUDE_ASM("asm/main/nonmatchings/tamer", tickEntityMoveTo);
 
 INCLUDE_ASM("asm/main/nonmatchings/tamer", tickEntityMoveToAxis);
 
-INCLUDE_ASM("asm/main/nonmatchings/tamer", worldPosToScreenPos2);
+static inline int16_t tamer_s16(int16_t a)
+{
+	return a;
+}
+void worldPosToScreenPos2(int16_t *x, int16_t *y, int16_t *z)
+{
+	SVECTOR v;
+	SVECTOR sxy;
+	int16_t new_var;
+
+	SetRotMatrix(&GsWSMATRIX);
+	SetTransMatrix(&GsWSMATRIX);
+	v.vx = *x;
+	v.vy = *y;
+	v.vz = *z;
+	gte_ldv0(&v);
+	gte_rtps();
+	gte_stsxy((long *)&sxy);
+	new_var = sxy.vx;
+	*x = tamer_s16(new_var) - (0xA0 - DRAWING_OFFSET_X);
+	*y = sxy.vy - (0x78 - DRAWING_OFFSET_Y);
+}
 
 uint8_t checkChestCollision(void)
 {

--- a/src/main/utils.c
+++ b/src/main/utils.c
@@ -1,14 +1,34 @@
 #include <libcd.h>
 
+#include <dw/clock.h>
 #include <dw/combat.h>
 #include <dw/main.h>
 #include <dw/params.h>
 #include <dw/entity.h>
+#include <dw/script.h>
 #include <dw/sound.h>
 #include <dw/ui.h>
 #include <dw/utils.h>
 
+#include <mwinline_n.h>
+
 #include "common.h"
+
+void MAIN_func_800D92EC(int32_t a, int32_t b, int32_t c, int32_t d);
+void MAIN_thunk_func_800D92EC(int32_t a, int32_t b, int32_t c, int32_t d);
+extern char MAIN_D_801345C4[];
+extern uint16_t MAIN_D_80134FFE;
+void setMapObjectsFlag(int16_t a, int16_t b, int32_t flag);
+typedef struct {
+	uint8_t map;
+	uint8_t lightOn;
+	int16_t a;
+	int16_t b;
+	uint16_t trigger;
+} MapLightEntry;
+
+void updateMapLightState(void);
+
 
 void damageTick(FighterData* fighter, Stats* stats);
 void sortItemsById(uint8_t *data, int32_t count);
@@ -164,7 +184,24 @@ void swapInt(int32_t *a, int32_t *b)
 	*b = tmp;
 }
 
-INCLUDE_ASM("asm/main/nonmatchings/utils", getEntityScreenPos);
+void getEntityScreenPos(Entity *e, int32_t boneId, int16_t *out)
+{
+	MATRIX *w;
+	SVECTOR v;
+	int16_t ox;
+
+	GsSetLsMatrix(&GsWSMATRIX);
+	w = &e->posData[boneId].posMatrix.workm;
+	v.vx = w->t[0];
+	v.vy = w->t[1];
+	v.vz = w->t[2];
+	gte_ldv0(&v);
+	gte_rtps();
+	gte_stsxy((long *)out);
+	ox = 0xA0 - DRAWING_OFFSET_X;
+	out[0] = out[0] - ox;
+	out[1] -= 0x78 - DRAWING_OFFSET_Y;
+}
 
 void MAIN_func_800E53B4(POLY_FT4* poly, int32_t x, int32_t y)
 {
@@ -346,7 +383,10 @@ void renderPauseBox(int32_t instanceId)
   renderString(0, (int16_t) ((*new_var).x + 6), (int16_t) ((*new_var).y + 6), 0x2A, 0xC, 0x78, 0xF0, 0, 1);
 }
 
-INCLUDE_ASM("asm/main/nonmatchings/utils", MAIN_thunk_func_800D92EC);
+void MAIN_thunk_func_800D92EC(int32_t a, int32_t b, int32_t c, int32_t d)
+{
+	MAIN_func_800D92EC(a, b, c, d);
+}
 
 void setMapLayerEnabled(uint8_t enabled)
 {
@@ -391,6 +431,28 @@ int32_t isTamerOnScreen(void)
 	return 0;
 }
 
-INCLUDE_ASM("asm/main/nonmatchings/utils", updateMapLightState);
+void updateMapLightState(void)
+{
+	int32_t i;
+	MapLightEntry *p;
+
+	p = (MapLightEntry *)MAIN_D_801345C4;
+	for (i = 0; i <= 0; i++, p++) {
+		if ((p->map == (MAIN_D_80134FFE & 0xFF)) &&
+		    ((p->trigger == 0xFFFF) || (isTriggerSet(p->trigger) != 0))) {
+			if ((HOUR >= 7) && (HOUR < 0x13)) {
+				if (p->lightOn == 0) {
+					setMapObjectsFlag(p->a, p->b, 0);
+				} else {
+					setMapObjectsFlag(p->a, p->b, 1);
+				}
+			} else if (p->lightOn == 1) {
+				setMapObjectsFlag(p->a, p->b, 0);
+			} else {
+				setMapObjectsFlag(p->a, p->b, 1);
+			}
+		}
+	}
+}
 
 INCLUDE_ASM("asm/main/nonmatchings/utils", startTournament);


### PR DESCRIPTION
Adds 17 matched functions:

- model.c: getEntityModelComponent, getEntityType
- utils.c: updateMapLightState, getEntityScreenPos, MAIN_thunk_func_800D92EC
- item.c: removeItem, handleItemSickness
- main.c: tickNewGameJijimon, recalculatePPandArena
- partner_impl.c: tickTirednessMechanics
- efe.c: initializeEFE, createCloudFX, removeAllCloudFX
- tamer.c: checkMedalConditions, worldPosToScreenPos2
- main_menu.c: createSavegameChecksum, renderMainMenu

Notes:

- Three declarations are aligned to the matched definitions: removeItem
  (item.h and a local prototype in overworld.c), getEntityModelComponent
  (model.h, char type), getEntityScreenPos (script.h, void return).
- main.ld gains a rodata slot for main_menu.c so renderMainMenu's switch
  table comes from the compiled object.
- tickEntityWalkTo is matched on my side with (uint8_t, uint8_t, int32_t,
  int32_t, int8_t), but script_engine.c/partner.c declare it with uint32_t
  parameters and changing either side breaks the compare. Left as a stub -
  happy to re-match it against whichever signature you prefer.
- findEFEDATFile compiles one instruction long on current main, left as a
  stub for now.

make compare passes from a clean regenerate + build.