### PR TITLE
Match MAIN_func_8010D034, findEFEDATFile and updateConditionAnimation

### DIFF
--- a/config/main.ld
+++ b/config/main.ld
@@ -152,6 +152,8 @@ SECTIONS
         . = ALIGN(., 4);
         build/src/main/script_draw.c.o(.text.*)
         . = ALIGN(., 4);
+        build/src/main/main_menu.c.o(".text.MAIN_func_8010D034")
+        . = ALIGN(., 4);
         build/src/main/main_menu.c.o(.text.*)
         . = ALIGN(., 16);
         main_TEXT_END = .;

--- a/src/main/efe.c
+++ b/src/main/efe.c
@@ -16,7 +16,7 @@ extern int16_t MAIN_D_801389B4[];
 extern char *EFE_FLASH_DATA;
 extern uint32_t MAIN_D_8012343C[];
 extern char MAIN_D_8012342C[];
-extern char MAIN_D_80134220[];
+extern char MAIN_D_80134220[4];
 extern int16_t EFE_LOADED_MOVE_DATA[];
 extern char EFE_SCRIPT_MEM1_DATA[];
 extern char *EFE_DATA_STACK;
@@ -300,7 +300,23 @@ void downloadSomeImage(void)
 
 INCLUDE_ASM("asm/main/nonmatchings/efe", modifySomeImage);
 
-INCLUDE_ASM("asm/main/nonmatchings/efe", findEFEDATFile);
+void findEFEDATFile(void)
+{
+	char name[0x40];
+	CdlFILE file;
+	uint8_t mode;
+	int32_t i;
+
+	i = 0;
+	while (CdReadSync(1, 0) != 0) {}
+	mode = 0x80;
+	name[0] = 0x5C;
+	strcpy(&name[1], MAIN_D_8012342C);
+	strcat(name, MAIN_D_80134220);
+	while ((int32_t)CdSearchFile(&file, name) == -1) {}
+	CdControl(0xE, &mode, 0);
+	MAIN_D_8012343C[i] = CdPosToInt(&file.pos);
+}
 
 void initializeEFE(void)
 {

--- a/src/main/main_menu.c
+++ b/src/main/main_menu.c
@@ -245,7 +245,7 @@ void *main_menu_order_anchor[] = {
 	MAIN_func_8010D034,
 };
 
-INCLUDE_ASM("asm/main/nonmatchings/main_menu", MAIN_func_8010D034);
+
 
 void renderText(POLY_FT4 *prim, int32_t x, int32_t y, uint8_t u, int32_t v,
 		int32_t w, int32_t h, int32_t textColor)
@@ -1534,4 +1534,20 @@ int32_t MAIN_func_80113A20(void)
 	}
 
 	return 0;
+}
+
+void MAIN_func_8010D034(void)
+{
+	POLY_FT4 *cur;
+
+	cur = (POLY_FT4 *)GsGetWorkBase();
+	renderText(cur++, 0x52, 0x37, 0, 0, 0xB0, 0xC, 0);
+	if (MAIN_D_80135030 != 0) {
+		renderText(cur++, 0x52, 0x43, 0, 0xC, 0xB0, 0x18, 0);
+	} else {
+		renderText(cur++, 0x52, 0x43, 0, 0xC, 0xB0, 0x18, 1);
+	}
+	renderText(cur++, 0x52, 0x5B, 0, 0x24, 0xB0, 0xC, 0);
+	GsSetWorkBase((PACKET *)cur);
+	renderMenuBox(0x48, 0x32, 0xB0, 0x3A);
 }

--- a/src/main/partner.c
+++ b/src/main/partner.c
@@ -836,7 +836,48 @@ void setPartnerSlowWalking(void)
 	startAnimation(ENTITY_TABLE[1], PARTNER_ANIMATION);
 }
 
-INCLUDE_ASM("asm/main/nonmatchings/partner", updateConditionAnimation);
+void updateConditionAnimation(void)
+{
+	int32_t cond;
+	int32_t anim;
+	int32_t v;
+
+	v = (cond = PARTNER_PARA.condition);
+	anim = PARTNER_ENTITY.digimonEntity.entity.anim.animId;
+	if (v == 0) {
+		if (PARTNER_PARA.happiness < -0x1E) {
+			PARTNER_ANIMATION = 7;
+		} else if (PARTNER_PARA.happiness >= 0x1F) {
+			PARTNER_ANIMATION = 5;
+		} else {
+			setPartnerIdle();
+		}
+	} else if ((cond & 0x20) || (cond & 0x40)) {
+		if (anim != 0xE) {
+			PARTNER_ANIMATION = 0xE;
+		}
+	} else if (cond & 8) {
+		if (anim != 0x10) {
+			PARTNER_ANIMATION = 0x10;
+		}
+	} else if (cond & 4) {
+		if (anim != 0xF) {
+			PARTNER_ANIMATION = 0xF;
+		}
+	} else if (cond & 2) {
+		if (anim != 0x12) {
+			PARTNER_ANIMATION = 0x12;
+		}
+	} else if (cond & 1) {
+		if (anim != 0x11) {
+			PARTNER_ANIMATION = 0x11;
+		}
+	} else if (cond & 0x10) {
+		if (anim != 0x13) {
+			PARTNER_ANIMATION = 0x13;
+		}
+	}
+}
 
 
 


### PR DESCRIPTION
Adds 3 matched functions:

- main_menu.c: MAIN_func_8010D034 (title screen text box). It only matches
  when the definition sits after renderText's, so it is placed at the end of
  the file and main.ld pins its .text section back to 0x8010D034.
- efe.c: findEFEDATFile. MAIN_D_80134220 needed a size for the gp-relative
  access, and the table index is a variable so the store keeps its addu.
- partner.c: updateConditionAnimation.

make compare passes from a clean regenerate + build (SLUS SHA1 identical
to disc).
