### PR TITLE
Match VS_renderVersusFlash and VS_addArenaRenderers

### DIFF
--- a/src/vs/vs_scene.c
+++ b/src/vs/vs_scene.c
@@ -329,7 +329,20 @@ void VS_unloadArenaAssets(void)
 {
 }
 
-INCLUDE_ASM("asm/vs/nonmatchings/vs_scene", VS_addArenaRenderers);
+void VS_addArenaRenderers(void)
+{
+	switch (VS_D_800716B2[0]) {
+	case 0:
+		addObject(0x1A7, 0, NULL, VS_renderArenaViewLeft);
+		break;
+	case 1:
+		addObject(0x1A7, 0, NULL, VS_renderArenaViewRight);
+		break;
+	case 2:
+		addObject(0x1A7, 0, NULL, VS_renderArenaViewFull);
+		break;
+	}
+}
 
 INCLUDE_ASM("asm/vs/nonmatchings/vs_scene", VS_renderArenaViewLeft);
 

--- a/src/vs/vs_scene.c
+++ b/src/vs/vs_scene.c
@@ -201,7 +201,25 @@ INCLUDE_ASM("asm/vs/nonmatchings/vs_scene", VS_loadFighterEntities);
 
 INCLUDE_ASM("asm/vs/nonmatchings/vs_scene", VS_unloadFighterEntities);
 
-INCLUDE_ASM("asm/vs/nonmatchings/vs_scene", VS_renderVersusFlash);
+void VS_renderVersusFlash(void)
+{
+	POLY_FT4 *prim;
+	int32_t y;
+
+	prim = (POLY_FT4 *)GsGetWorkBase();
+	SetPolyFT4(prim);
+	prim->r0 = 0x80;
+	prim->g0 = 0x80;
+	prim->b0 = 0x80;
+	prim->tpage = 5;
+	prim->clut = GetClut(0x40, 0x1E9);
+	setUVDataPolyFT4(prim, 0x30, 0x10, 0x4E, 0x18);
+
+	y = MAIN_D_80135261 * 20 - 0x39;
+	setPosDataPolyFT4(prim, -0x27, y, 0x4E, 0x18);
+	AddPrim(ACTIVE_ORDERING_TABLE->org + 0x1E, prim++);
+	GsSetWorkBase((PACKET *)prim);
+}
 
 INCLUDE_ASM("asm/vs/nonmatchings/vs_scene", VS_renderFighterNamePlate);
 


### PR DESCRIPTION
## Matched functions

- `VS_renderVersusFlash` (src/vs/vs_scene.c)
- `VS_addArenaRenderers` (src/vs/vs_scene.c)

## Notes

All changes verified with `make compare` — compiled binaries match target binaries.

`VS_addArenaRenderers` was originally attempted as an if-else, but the disassembly 
indicated a switch statement instead (the if-else version produced a spurious register 
copy not present in the target).