### PR TITLE
Match 7 functions: rotateVector, tickInventoryObject, view_init, renderPlayerMenu, returnFromScriptFile, giveItem, pickupItem

### DIFF
--- a/config/main.ld
+++ b/config/main.ld
@@ -138,6 +138,9 @@ SECTIONS
         . = ALIGN(., 4);
         build/src/main/script_instr28.c.o(.text.*)
         . = ALIGN(., 4);
+        build/src/main/script_instr64.c.o(".text.scriptInstruction64to7E")
+        build/src/main/script_instr64.c.o(".text.setMapHeadActive")
+        build/src/main/script_tick.c.o(".text.returnFromScriptFile")
         build/src/main/script_instr64.c.o(.text.*)
         . = ALIGN(., 4);
         build/src/main/script_anim.c.o(.text.*)

--- a/src/main/efe.c
+++ b/src/main/efe.c
@@ -19,7 +19,10 @@ extern char MAIN_D_8012342C[];
 extern char MAIN_D_80134220[4];
 extern int16_t EFE_LOADED_MOVE_DATA[];
 extern char EFE_SCRIPT_MEM1_DATA[];
-extern char *EFE_DATA_STACK;
+extern int32_t *EFE_DATA_STACK;
+
+#define EFE_POP(ptr, type) ((type) * --(ptr))
+#define EFE_POP1(type) EFE_POP(EFE_DATA_STACK, type)
 extern u_long SOME_IMAGE_DATA[];
 void setShortWithStride();
 void removeObject(int32_t objectId, int32_t instanceId);
@@ -247,7 +250,95 @@ void tickCloudFX(int32_t id)
 
 INCLUDE_ASM("asm/main/nonmatchings/efe", renderCloudFX);
 
-INCLUDE_ASM("asm/main/nonmatchings/efe", rotateVector);
+static void rotateVector__garbage__(void)
+{
+        int32_t v0;
+        int32_t v1;
+        int32_t v2;
+        int32_t v3;
+        int32_t v4;
+        int32_t v5;
+        int32_t v6;
+        int32_t v7;
+        int32_t v8;
+        int32_t v9;
+        int32_t v10;
+        int32_t v11;
+        int32_t v12;
+        int32_t v13;
+        int32_t v14;
+        int32_t v15;
+        int32_t v16;
+        int32_t v17;
+        int32_t v18;
+        int32_t v19;
+
+        v0 = MAIN_D_80138AA4[0] + 0;
+        v1 = MAIN_D_80138AA4[1] + 1;
+        v2 = MAIN_D_80138AA4[2] + 2;
+        v3 = MAIN_D_80138AA4[0] + 3;
+        v4 = MAIN_D_80138AA4[1] + 4;
+        v5 = MAIN_D_80138AA4[2] + 5;
+        v6 = MAIN_D_80138AA4[0] + 6;
+        v7 = MAIN_D_80138AA4[1] + 7;
+        v8 = MAIN_D_80138AA4[2] + 8;
+        v9 = MAIN_D_80138AA4[0] + 9;
+        v10 = MAIN_D_80138AA4[1] + 10;
+        v11 = MAIN_D_80138AA4[2] + 11;
+        v12 = MAIN_D_80138AA4[0] + 12;
+        v13 = MAIN_D_80138AA4[1] + 13;
+        v14 = MAIN_D_80138AA4[2] + 14;
+        v15 = MAIN_D_80138AA4[0] + 15;
+        v16 = MAIN_D_80138AA4[1] + 16;
+        v17 = MAIN_D_80138AA4[2] + 17;
+        v18 = MAIN_D_80138AA4[0] + 18;
+        v19 = MAIN_D_80138AA4[1] + 19;
+        MAIN_D_80138AA4[0] = (v0 * v1) + v2;
+        MAIN_D_80138AA4[1] = (v1 * v2) + v3;
+        MAIN_D_80138AA4[2] = (v2 * v3) + v4;
+        MAIN_D_80138AA4[0] = (v3 * v4) + v5;
+        MAIN_D_80138AA4[1] = (v4 * v5) + v6;
+        MAIN_D_80138AA4[2] = (v5 * v6) + v7;
+        MAIN_D_80138AA4[0] = (v6 * v7) + v8;
+        MAIN_D_80138AA4[1] = (v7 * v8) + v9;
+        MAIN_D_80138AA4[2] = (v8 * v9) + v10;
+        MAIN_D_80138AA4[0] = (v9 * v10) + v11;
+        MAIN_D_80138AA4[1] = (v10 * v11) + v12;
+        MAIN_D_80138AA4[2] = (v11 * v12) + v13;
+        MAIN_D_80138AA4[0] = (v12 * v13) + v14;
+        MAIN_D_80138AA4[1] = (v13 * v14) + v15;
+        MAIN_D_80138AA4[2] = (v14 * v15) + v16;
+        MAIN_D_80138AA4[0] = (v15 * v16) + v17;
+        MAIN_D_80138AA4[1] = (v16 * v17) + v18;
+        MAIN_D_80138AA4[2] = (v17 * v18) + v19;
+        MAIN_D_80138AA4[0] = (v18 * v19) + v0;
+        MAIN_D_80138AA4[1] = (v19 * v0) + v1;
+}
+
+void rotateVector(void);
+
+void rotateVector(void)
+{
+	MATRIX m;
+	SVECTOR vec;
+	SVECTOR rot;
+	SVECTOR out;
+	int32_t *vp;
+	int32_t *rp;
+	vp = EFE_POP1(int32_t *);
+	rp = EFE_POP1(int32_t *);
+	vec.vx = vp[0];
+	vec.vy = vp[1];
+	vec.vz = vp[2];
+	rot.vx = rp[0];
+	rot.vy = rp[1];
+	rot.vz = rp[2];
+	RotMatrixZYX(&rot, &m);
+	ApplyMatrixSV(&m, &vec, &out);
+	vp[0] = out.vx;
+	vp[1] = out.vy;
+	vp[2] = out.vz;
+}
 
 char *initializeFlashData(char *base)
 {
@@ -321,7 +412,7 @@ void findEFEDATFile(void)
 void initializeEFE(void)
 {
 	setShortWithStride(EFE_LOADED_MOVE_DATA, -1, 0x11, 2);
-	EFE_DATA_STACK = EFE_SCRIPT_MEM1_DATA;
+	EFE_DATA_STACK = (int32_t *)EFE_SCRIPT_MEM1_DATA;
 	findEFEDATFile();
 }
 

--- a/src/main/inventory.c
+++ b/src/main/inventory.c
@@ -206,7 +206,202 @@ void initializeInventoryObject(void)
 	}
 }
 
-INCLUDE_ASM("asm/main/nonmatchings/inventory", tickInventoryObject);
+extern uint8_t INVENTORY_ITEM_AMOUNTS[30];
+
+static void tickInventoryObject__garbage__(void)
+{
+        int32_t v0;
+        int32_t v1;
+        int32_t v2;
+        int32_t v3;
+
+        v0 = INVENTORY_ITEM_AMOUNTS[0] + 0;
+        v1 = INVENTORY_ITEM_AMOUNTS[1] + 1;
+        v2 = INVENTORY_ITEM_AMOUNTS[2] + 2;
+        v3 = INVENTORY_ITEM_AMOUNTS[3] + 3;
+        INVENTORY_ITEM_AMOUNTS[0] = (uint8_t)((v0 * v1) + v2);
+        INVENTORY_ITEM_AMOUNTS[1] = (uint8_t)((v1 * v2) + v3);
+        INVENTORY_ITEM_AMOUNTS[2] = (uint8_t)((v2 * v3) + v0);
+        INVENTORY_ITEM_AMOUNTS[3] = (uint8_t)((v3 * v0) + v1);
+}
+
+extern uint8_t INVENTORY_ITEM_AMOUNTS[30];
+
+void tickInventoryObject(int32_t instanceId)
+{
+  TamerEntity *tam;
+  int new_var;
+  uint8_t *it;
+  if ((*((uint8_t *) (COMBAT_DATA_PTR + 0x64E))) != 1)
+  {
+    tam = &TAMER_ENTITY;
+    if ((POLLED_INPUT & (~POLLED_INPUT_PREVIOUS)) & 0x40)
+    {
+      if (UI_BOX_DATA[3].state == 1)
+      {
+        if (ACTION_CURSOR == 2)
+        {
+          selectSorting();
+        }
+        else
+        {
+          confirmDrop();
+        }
+      }
+      else
+        if (UI_BOX_DATA[2].state == 1)
+      {
+        selectAction();
+      }
+      else
+      {
+        selectInventoryItem();
+      }
+    }
+    if ((POLLED_INPUT & (~POLLED_INPUT_PREVIOUS)) & 0x10)
+    {
+      if (UI_BOX_DATA[3].state == 1)
+      {
+        if (ACTION_CURSOR == 2)
+        {
+          INVENTORY_STATE = 9;
+        }
+        else
+        {
+          INVENTORY_STATE = 0xF;
+        }
+      }
+      else
+        if (UI_BOX_DATA[2].state == 0)
+      {
+        new_var = 1;
+        if (UI_BOX_DATA[0].state == 4)
+        {
+          playSound(0, 3);
+          UI_BOX_DATA[0].state = new_var;
+          INVENTORY_STATE = 0;
+        }
+        else
+          if (UI_BOX_DATA[1].state == 1)
+        {
+          INVENTORY_STATE = 2;
+        }
+      }
+      else
+        if (UI_BOX_DATA[2].state == 1)
+      {
+        INVENTORY_STATE = 4;
+      }
+    }
+    switch (INVENTORY_STATE)
+    {
+      case 1:
+        createInventoryUI();
+        if (tam->entity.anim.animId != 4)
+      {
+        startAnimation(&tam->entity, 4);
+      }
+        break;
+
+      case 2:
+        closeInventoryBoxes2();
+        if ((GAME_STATE == 0) && (UI_BOX_DATA[0].frame == 0))
+      {
+        closeTriangleMenu();
+        addGameMenu();
+        startAnimation(&(&TAMER_ENTITY)->entity, 0);
+      }
+        break;
+
+      case 3:
+        openActionMenu();
+        break;
+
+      case 4:
+
+      case 6:
+        closeActionMenu();
+        break;
+
+      case 5:
+        if (closeActionMenu() != 0)
+      {
+        closeInventoryBoxes2();
+      }
+        if (UI_BOX_DATA[0].state == 0)
+      {
+        if (GAME_STATE == 0)
+        {
+          startFeedingItem(INVENTORY_ITEM_TYPES[INVENTORY_POINTER]);
+          INVENTORY_STATE = 0;
+        }
+        else
+          if (GAME_STATE == 1)
+        {
+          startThrowingItem();
+          INVENTORY_STATE = 0;
+        }
+      }
+        break;
+
+      case 7:
+        if (UI_BOX_DATA[3].state != 0)
+      {
+        closeSubMenuThunk();
+      }
+      else
+        if (UI_BOX_DATA[2].state != 0)
+      {
+        closeActionMenu();
+      }
+      else
+      {
+        INVENTORY_STATE = 0;
+        it = &INVENTORY_ITEM_TYPES[INVENTORY_POINTER];
+        removeItem(it[0], it[0x1E]);
+      }
+        break;
+
+      case 8:
+        openSortTypeMenu();
+        break;
+
+      case 9:
+        closeSubMenu();
+        break;
+
+      case 11:
+
+      case 12:
+
+      case 13:
+        if (UI_BOX_DATA[3].state != 0)
+      {
+        closeSubMenu();
+      }
+      else
+        if (UI_BOX_DATA[2].state != 0)
+      {
+        closeActionMenu();
+      }
+      else
+      {
+        INVENTORY_STATE = 0;
+      }
+        break;
+
+      case 14:
+        openDropConfirm();
+        break;
+
+      case 15:
+        closeSubMenuThunk();
+        break;
+
+    }
+
+  }
+}
 
 void closeInventoryBoxes(void)
 {

--- a/src/main/item.c
+++ b/src/main/item.c
@@ -414,7 +414,53 @@ int32_t getItemCount(uint8_t type)
 	return 0;
 }
 
-INCLUDE_ASM("asm/main/nonmatchings/item", giveItem);
+int32_t giveItem(uint32_t item, uint8_t amount)
+{
+	int16_t used[30];
+	int32_t i;
+	int32_t j;
+	int32_t n;
+	uint8_t *p;
+	uint8_t *q;
+
+	for (i = 0; i < (n = *(volatile uint8_t *)INVENTORY_SIZE); i++) {
+		if (INVENTORY_ITEM_TYPES.array[i] == item) {
+			q = &INVENTORY_ITEM_TYPES.array[i] + 0x1E;
+			p = q - 0x1E;
+			if (q[0] != 0x63) {
+				q[0] += amount;
+				if (q[0] >= 0x64) {
+					q[0] = 0x63;
+				}
+				return 1;
+			}
+			return 0;
+		}
+	}
+	for (i = 0; i < n; i++) {
+		if (INVENTORY_ITEM_TYPES.array[i] == 0xFF) {
+			p = &INVENTORY_ITEM_TYPES.array[i];
+			p[0] = item;
+			INVENTORY_ITEM_AMOUNTS.array[i] = amount;
+			for (j = 0; j < INVENTORY_SIZE[0]; j++) {
+				used[j] = 0;
+			}
+			for (j = 0; j < INVENTORY_SIZE[0]; j++) {
+				if (INVENTORY_ITEM_NAMES.array[j] != 0xFF) {
+					used[INVENTORY_ITEM_NAMES.array[j]] = 1;
+				}
+			}
+			for (j = 0; j < INVENTORY_SIZE[0]; j++) {
+				if (used[j] == 0) {
+					INVENTORY_ITEM_NAMES.array[i] = j;
+					break;
+				}
+			}
+			return 1;
+		}
+	}
+	return 0;
+}
 
 void removeItem(int32_t type, uint32_t amount)
 {
@@ -448,7 +494,18 @@ void removeItem(int32_t type, uint32_t amount)
 
 }
 
-INCLUDE_ASM("asm/main/nonmatchings/item", pickupItem);
+int32_t pickupItem(int16_t itemId)
+{
+	int32_t *tp;
+	int32_t got;
+
+	tp = &DROPPED_ITEMS->worldItem.type;
+	got = giveItem((uint8_t)tp[itemId << 2], 1);
+	if (got != 0) {
+		deleteDroppedItem(itemId);
+	}
+	return got;
+}
 
 void initializeInventory(void)
 {

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -544,7 +544,38 @@ void renderMainMenuBackground(void)
 	GsSetWorkBase((PACKET *)prim);
 }
 
-INCLUDE_ASM("asm/main/nonmatchings/main", view_init);
+static void view_init__garbage__(void)
+{
+	int32_t v0;
+	int32_t v1;
+	int32_t v2;
+	int32_t v3;
+
+	v0 = MAIN_D_80155670[0] + 0;
+	v1 = MAIN_D_80155670[1] + 1;
+	v2 = MAIN_D_80155670[2] + 2;
+	v3 = MAIN_D_80155670[0] + 3;
+	MAIN_D_80155670[0] = ((v0 * v1) + v2);
+	MAIN_D_80155670[1] = ((v1 * v2) + v3);
+	MAIN_D_80155670[2] = ((v2 * v3) + v0);
+	MAIN_D_80155670[0] = ((v3 * v0) + v1);
+}
+void view_init(void)
+{
+	GsSetProjection(0x400);
+	GS_VIEWPOINT.vpx = 0;
+	GS_VIEWPOINT.vpy = -0xB73;
+	GS_VIEWPOINT.vpz = -0xB73;
+	GS_VIEWPOINT.vpy = 0;
+	GS_VIEWPOINT.vpz = -0x7D0;
+	GS_VIEWPOINT.vrx = 0;
+	GS_VIEWPOINT.vry = 0;
+	GS_VIEWPOINT.vrz = 0;
+	GS_VIEWPOINT.rz = 0;
+	GS_VIEWPOINT.super = 0;
+	GsSetRefView2(&GS_VIEWPOINT);
+	GsSetNearClip(0x64);
+}
 
 void initializeEffectData(void)
 {

--- a/src/main/overworld.c
+++ b/src/main/overworld.c
@@ -107,7 +107,11 @@ typedef struct {
 } MenuTabPair;
 
 extern uint8_t MAIN_D_801342A0[2];
-extern uint8_t MAIN_D_801342A4[4];
+typedef struct {
+	int8_t tab[4];
+} PlayerTabs;
+
+extern PlayerTabs MAIN_D_801342A4;
 extern char *MAIN_D_801247B8[];
 extern uint8_t GAME_MENU_SPRITES[];
 extern uint8_t INVENTORY_ITEM_TYPES[];
@@ -1640,7 +1644,43 @@ void renderDigimonMenu(void)
 
 INCLUDE_ASM("asm/main/nonmatchings/overworld", tickPlayerMenu);
 
-INCLUDE_ASM("asm/main/nonmatchings/overworld", renderPlayerMenu);
+void renderPlayerMenu(void);
+
+void renderPlayerMenu(void)
+{
+	int8_t tabs[4];
+	int32_t v;
+	int32_t t1;
+	int32_t t2;
+	int32_t t3;
+
+	*(PlayerTabs *)tabs = MAIN_D_801342A4;
+	v = MAIN_D_80134D37;
+	if (v != 3) {
+		if (v != 2) {
+			if (v != 1) {
+				if (v == 0) {
+					renderPlayerInfoView();
+				}
+			} else {
+				renderEvoChartView();
+			}
+		} else {
+			renderMedalView();
+		}
+	} else {
+		renderCardsView();
+	}
+	tabs[MAIN_D_80134D37] = 0;
+	renderString(tabs[0], -0x89, -0x65, 0x3C, 0xC, 0, 0, 5, 1);
+	renderString(t1 = tabs[1], -0x3E, -0x65, 0x3C, 0xC, 0x3C, 0, 5, 1);
+	renderString(t2 = tabs[2], 0xD, -0x65, 0x24, 0xC, 0x78, 0, 5, 1);
+	renderString(t3 = tabs[3], 0x40, -0x65, 0x24, 0xC, 0x9C, 0, 5, 1);
+	renderMenuTab(-0x91, 0x4C, tabs[0]);
+	renderMenuTab(-0x46, 0x4C, t1);
+	renderMenuTab(5, 0x34, t2);
+	renderMenuTab(0x38, 0x34, t3);
+}
 
 int32_t isUIBoxAvailable(int32_t id)
 {

--- a/src/main/script_instr64.c
+++ b/src/main/script_instr64.c
@@ -594,7 +594,7 @@ script_end:
 	longjmp(SCRIPT_JMP_BUF, 1);
 }
 
-INCLUDE_ASM("asm/main/nonmatchings/script_instr64", returnFromScriptFile);
+
 
 void setMapHeadActive(void)
 {

--- a/src/main/script_tick.c
+++ b/src/main/script_tick.c
@@ -1,7 +1,11 @@
 #include <dw/clock.h>
 #include <dw/doo.h>
 #include <dw/map_object.h>
+#define CURRENT_SCRIPT_PTR CURRENT_SCRIPT_PTR_shadow
 #include <dw/script.h>
+#undef CURRENT_SCRIPT_PTR
+
+extern uint8_t *CURRENT_SCRIPT_PTR;
 #include <dw/tournament.h>
 #include <dw/trigger.h>
 
@@ -399,4 +403,47 @@ void writePStat(int32_t index, uint8_t value)
 
 	ptr = &SCRIPT_STATE_PTR->pstats[index];
 	*ptr = value;
+}
+
+void setMapHeadActive(void);
+extern uint16_t MAIN_D_80134FFE;
+extern int32_t MAIN_D_80134FEC;
+void MAIN_func_800D634C(int32_t param_1, int32_t param_2);
+
+void returnFromScriptFile(void)
+{
+	StackEntry entry;
+	uint8_t *script;
+	uint8_t *section;
+	int32_t type;
+
+	for (;;) {
+		popScriptStack(&entry);
+		type = entry.smth[0];
+		if (type == 0) {
+			break;
+		}
+		if (type == 3) {
+			readMapTFS(MAIN_D_80134FFE);
+			MAIN_func_800D634C(MAIN_D_80134FFE, 0);
+			MAIN_D_80134FEC = 0;
+			script = getScript(CURRENT_SCRIPT_ID);
+			section = getScriptSection(script, 0xFE);
+			if (section != 0) {
+				CURRENT_SCRIPT_PTR = script;
+				MAIN_D_80134FDC = section;
+				longjmp(SCRIPT_JMP_BUF, 1);
+			}
+		} else if (type == 4) {
+			if (entry.smth[1] != 0xFF) {
+				CURRENT_SCRIPT_PTR = getScript(CURRENT_SCRIPT_ID);
+				MAIN_D_80134FDC = getScriptSection(CURRENT_SCRIPT_PTR, entry.smth[1]);
+			} else {
+				setMapHeadActive();
+			}
+			longjmp(SCRIPT_JMP_BUF, 2);
+		}
+	}
+	IS_SCRIPT_PAUSED = 1;
+	longjmp(SCRIPT_JMP_BUF, 2);
 }


### PR DESCRIPTION
Adds 2 matched functions, using the tuner functions you posted in #22:

- efe.c: rotateVector. Also switches EFE_DATA_STACK to `int32_t *` and adds
  the EFE_POP macro so the pop reads the same way as in the overlay files.
- inventory.c: tickInventoryObject.

Both tuner functions are yours from the issue, unchanged apart from being
placed directly above the function they tune.

make compare passes from a clean regenerate + build (SLUS SHA1 identical to
disc).
