### PR TITLE
Match setEFEFlashOffset and STD_func_80064FCC

### DIFF
--- a/src/main/efe.c
+++ b/src/main/efe.c
@@ -98,7 +98,7 @@ static inline int16_t *efe_s16ptr(char *arg0)
 void createFlash();
 void tickEFEFlash();
 void renderEFEFlash(int32_t layer);
-void setEFEFlashOffset(int32_t id, int16_t x, int16_t y);
+volatile unsigned long setEFEFlashOffset(int32_t id, int16_t x, int16_t y);
 void downloadSomeImage();
 void modifySomeImage(int32_t dim, int16_t stp);
 void findEFEDATFile(void);
@@ -284,7 +284,16 @@ void tickEFEFlash(int32_t id)
 
 INCLUDE_ASM("asm/main/nonmatchings/efe", renderEFEFlash);
 
-INCLUDE_ASM("asm/main/nonmatchings/efe", setEFEFlashOffset);
+volatile unsigned long setEFEFlashOffset(int32_t id, int16_t x, int16_t y)
+{
+	char *e;
+	char *new_var;
+
+	new_var = EFE_FLASH_DATA + (id *= 0x28);
+	e = new_var;
+	((int16_t *)e)[18] = x;
+	((int16_t *)e)[19] = y;
+}
 
 void downloadSomeImage(void)
 {

--- a/src/std/std_main.c
+++ b/src/std/std_main.c
@@ -397,7 +397,7 @@ int32_t BTL_getUsableMoves(int16_t *out, int16_t index);
 void VS__func_800F1E9C(Entity *entity, int32_t id);
 void BTL_clearConfusion(DigimonEntity *digimon, FighterData *fighter);
 void STD_func_8005A44C(void);
-void STD_func_80064FCC(int32_t count);
+void STD_func_80064FCC(unsigned short count);
 int16_t BTL_calculateHitChance(DigimonEntity *attacker, DigimonEntity *defender, FighterData *fighter, int16_t move);
 void BTL_retargetAfterHit(DigimonEntity *digimon, FighterData *fighter, AttackObject attack);
 void BTL_startQueuedMove(DigimonEntity *digimon, DigimonEntity *target, FighterData *fighter);
@@ -3068,7 +3068,14 @@ void STD_startHitAnimation(Entity *entity, AttackObject *attack, int32_t animId)
 	createParticleFX(MOVE_DATA[tech].special, 1, &attack->position, entity, MOVE_DATA[tech].iframes + 0x10);
 }
 
-INCLUDE_ASM("asm/std/nonmatchings/std_main", STD_func_80064FCC);
+void STD_func_80064FCC(unsigned short count)
+{
+	int32_t i;
+
+	for (i = 0; i <= count; i++) {
+		STD_battleTickFrame();
+	}
+}
 
 void STD_battleTickFrame(void)
 {


### PR DESCRIPTION
Matched 100%:
- `setEFEFlashOffset` (src/main/efe.c) — resolved with decomp-permuter;
  required inlining `id *= 0x28` and typing the return as
  `volatile unsigned long` (instead of `void`) for correct delay-slot
  scheduling.
- `STD_func_80064FCC` (src/std/std_main.c) — resolved with decomp-permuter;
  `for (i = 0; i <= count; i++)` loop with the parameter typed as
  `unsigned short count` (not `int32_t`).

`make compare` validated clean.