### PR TITLE
Match closeUIBoxIfOpen and scriptUpdateEnergyBoundaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,9 @@
 .venv/
 asm/
-assets/
 bin/
 build/
 disks/
 expected/
 permuter/
-CLAUDE.md
 local.mk
 objdiff.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 .venv/
 asm/
+assets/
 bin/
 build/
 disks/
 expected/
 permuter/
+CLAUDE.md
 local.mk
 objdiff.json

--- a/src/main/overworld.c
+++ b/src/main/overworld.c
@@ -139,6 +139,7 @@ void handleGameMenuSelection(int32_t selection);
 void createMenuBox(int32_t a, int32_t b, int32_t c, int32_t d, int32_t e,
 		   int32_t f, void (*tick)(void), void (*render)(void));
 void closeUIBoxIfOpen(int32_t arg);
+void getEntityScreenPos(Entity *entity, int32_t flag, int16_t *outPos);
 void initializeInventoryObject(void);
 void clearTextArea(void);
 void tickGameMenu(void);
@@ -1593,7 +1594,15 @@ void closeTriangleMenu(void)
 	removeObject(0xfa4, 0);
 }
 
-INCLUDE_ASM("asm/main/nonmatchings/overworld", closeUIBoxIfOpen);
+void closeUIBoxIfOpen(int32_t id)
+{
+	int16_t pos[2];
+
+	if (UI_BOX_DATA[id].frame >= 5 && UI_BOX_DATA[id].state == 1) {
+		getEntityScreenPos(ENTITY_TABLE[0], 0, pos);
+		removeAnimatedUIBox(id, 0);
+	}
+}
 
 INCLUDE_ASM("asm/main/nonmatchings/overworld", renderGameMenu);
 

--- a/src/main/script_anim.c
+++ b/src/main/script_anim.c
@@ -1,8 +1,29 @@
 #include <dw/partner.h>
+#include <dw/params.h>
 #include <dw/script.h>
 
 #include "common.h"
 
+typedef struct {
+	int8_t hungerTimes[8];
+	uint8_t energyCap;
+	uint8_t energyThreshold;
+	int8_t energyUsage;
+	int16_t poopTimer;
+	int16_t unk2;
+	uint8_t poopSize;
+	uint8_t favoriteFood;
+	int8_t sleepCycle;
+	int8_t favoredRegion;
+	int8_t trainingType;
+	int8_t defaultWeight;
+	int16_t viewX;
+	int16_t viewY;
+	int16_t viewZ;
+} RaiseData;
+
+extern RaiseData RAISE_DATA[66];
+void setFoodTimer(int32_t type);
 void setActiveAnim(int32_t state);
 
 static void *script_anim_functions[] = {
@@ -13,7 +34,19 @@ static void *script_anim_functions[] = {
 	MAIN_func_801050C0,
 };
 
-INCLUDE_ASM("asm/main/nonmatchings/script_anim", scriptUpdateEnergyBoundaries);
+void scriptUpdateEnergyBoundaries(int32_t a0, int32_t a1)
+{
+	if (PARTNER_PARA.energyLevel > RAISE_DATA[PARTNER_ENTITY.digimonEntity.entity.type].energyCap) {
+		PARTNER_PARA.energyLevel = RAISE_DATA[PARTNER_ENTITY.digimonEntity.entity.type].energyCap;
+	}
+	if (PARTNER_PARA.condition & 4) {
+		if (RAISE_DATA[PARTNER_ENTITY.digimonEntity.entity.type].energyThreshold <= PARTNER_PARA.energyLevel) {
+			PARTNER_PARA.condition &= ~4;
+			setFoodTimer(PARTNER_ENTITY.digimonEntity.entity.type);
+			PARTNER_PARA.starvationTimer = 0;
+		}
+	}
+}
 
 void MAIN_func_801053EC(void)
 {


### PR DESCRIPTION
Matched 100%:
- `closeUIBoxIfOpen` — required a prototype for `getEntityScreenPos` in
  overworld.c.
- `scriptUpdateEnergyBoundaries` (src/main/script_anim.c) — required
  `setFoodTimer` to be declared with an `int32_t` parameter (not
  `int16_t`) to match the argument codegen, plus reversing the
  comparison against `energyThreshold`.
  
  
  `make compare` validated clean.