### PR TITLE
Match MAIN_func_800DF804

### DIFF
--- a/src/main/entity_text.c
+++ b/src/main/entity_text.c
@@ -25,7 +25,29 @@ void *entity_text_order_anchor[] = {
 	MAIN_func_800DF804,
 };
 
-INCLUDE_ASM("asm/main/nonmatchings/entity_text", MAIN_func_800DF804);
+void MAIN_func_800DF804()
+{
+	int32_t id;
+	int32_t i;
+	int32_t ofs;
+	uint8_t *p;
+
+	id = 0;
+	p = &MAIN_D_80150CD0[id * 0x8C];
+	while (id < 4) {
+		i = 0;
+		ofs = 0;
+		while (i < 8) {
+			(&p[ofs])[0x10] = 0xFF;
+			(&p[i])[0x84] = 0xFF;
+			i += 1;
+			ofs += 0x10;
+		}
+		*(int32_t *)p = 0;
+		id += 1;
+		p += 0x8C;
+	}
+}
 
 INCLUDE_ASM("asm/main/nonmatchings/entity_text", addEntityText);
 


### PR DESCRIPTION
Matches `MAIN_func_800DF804` in `src/main/entity_text.c`, which resets the four combat-text slots.

The inner loop is the same one already matched in `removeEntityText` just below it.

Verified with a full clean build: `make compare` reports all binaries matching, and `build/SLUS_010.32` has SHA1 `31ec666b987d5b007dec40eecc4092d27ed9085b`.